### PR TITLE
Add shooting animation display for shots

### DIFF
--- a/src/PlayerStuff/Knight.cs
+++ b/src/PlayerStuff/Knight.cs
@@ -14,8 +14,8 @@ public class Knight: Player
 
 
     //Konstruktor for Knight
-    public Knight(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D special_move_texture, int player, PlayerControls controls)
-              : base(graphicsDevice, position1, texture1, special_move_texture, player, controls)
+    public Knight(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D shoot_texture, Texture2D special_move_texture, int player, PlayerControls controls)
+              : base(graphicsDevice, position1, texture1, shoot_texture, special_move_texture, player, controls)
     {}
 
 

--- a/src/PlayerStuff/Mario.cs
+++ b/src/PlayerStuff/Mario.cs
@@ -21,8 +21,8 @@ public class Mario : Player
 
 
 
-    public Mario(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D special_move_texture, int player, PlayerControls controls)
-              : base(graphicsDevice, position1, texture1, special_move_texture, player, controls)
+    public Mario(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D shoot_texture, Texture2D special_move_texture, int player, PlayerControls controls)
+              : base(graphicsDevice, position1, texture1, shoot_texture, special_move_texture, player, controls)
     { }
 
     public override void do_special_effect(float delta)

--- a/src/PlayerStuff/Ninja.cs
+++ b/src/PlayerStuff/Ninja.cs
@@ -11,8 +11,8 @@ public class Ninja : Player
     public int cooldown = 10; //can activate its special effect all x seconds
 
 
-    public Ninja(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D special_move_texture1, int player, PlayerControls controls)
-              : base(graphicsDevice, position1, texture1, special_move_texture1, player, controls)
+    public Ninja(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D shoot_texture, Texture2D special_move_texture1, int player, PlayerControls controls)
+              : base(graphicsDevice, position1, texture1, shoot_texture, special_move_texture1, player, controls)
     { }
 
     public override void do_special_effect(float delta)

--- a/src/PlayerStuff/Player.cs
+++ b/src/PlayerStuff/Player.cs
@@ -20,6 +20,10 @@ public class Player
 
     public Texture2D texture;
     public Texture2D special_move_texture;
+    public Texture2D shoot_texture;
+
+    public DateTime last_time_shot = DateTime.MinValue;
+    public TimeSpan shot_animation_duration = TimeSpan.FromMilliseconds(200);
 
     public Player otherPlayer;
     public int playerGroup;
@@ -146,13 +150,14 @@ public class Player
      */
 
 
-    public Player(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D special_move_texture1, int player, PlayerControls controls)
+    public Player(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D shoot_texture1, Texture2D special_move_texture1, int player, PlayerControls controls)
     {
         position = position1;
         playerGroup = player;
         moving_direction = get_moving_direction_from_player_group();
 
         texture = texture1;
+        shoot_texture = shoot_texture1;
         special_move_texture = special_move_texture1;
 
         currentRect = new Rectangle((int)position.X, (int)position.Y, RectangleWidth, RectangleHeight);
@@ -237,9 +242,9 @@ public class Player
             jump(delta);
         }
 
-        if (InputHandler.IsDown(controls.getKey(PlayerAction.Lupfer)))      { shoots_lupfer = true;    }
-        if (InputHandler.IsDown(controls.getKey(PlayerAction.Diagonal)))    { shoots_diagonal = true;  }
-        if (InputHandler.IsDown(controls.getKey(PlayerAction.Horizontal)))  { shoots_horizontal = true;}
+        if (InputHandler.IsDown(controls.getKey(PlayerAction.Lupfer)))      { shoots_lupfer = true;    last_time_shot = DateTime.Now; }
+        if (InputHandler.IsDown(controls.getKey(PlayerAction.Diagonal)))    { shoots_diagonal = true;  last_time_shot = DateTime.Now; }
+        if (InputHandler.IsDown(controls.getKey(PlayerAction.Horizontal)))  { shoots_horizontal = true;last_time_shot = DateTime.Now; }
 
         if (InputHandler.IsDown(controls.getKey(PlayerAction.Special)))     do_special_effect(delta);
         if (InputHandler.IsDown(controls.getKey(PlayerAction.PowerUp_1)))   activate_powerUP(1);
@@ -280,14 +285,23 @@ public class Player
 
 
         if (InputHandler.IsGamePadButtonDown(Buttons.Y, playerGroup))
+        {
             shoots_horizontal = true;
+            last_time_shot = DateTime.Now;
+        }
 
         if (InputHandler.IsGamePadButtonDown(Buttons.B, playerGroup))
         {
             if (InputHandler.IsGamePadButtonDown(Buttons.LeftShoulder, playerGroup))
+            {
                 shoots_lupfer = true;
+                last_time_shot = DateTime.Now;
+            }
             else
+            {
                 shoots_diagonal = true;
+                last_time_shot = DateTime.Now;
+            }
         }
 
 
@@ -357,21 +371,35 @@ public class Player
 
 //------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------
-// draw 
+// draw
+
+    protected Texture2D get_current_texture()
+    {
+        if (shoot_texture != null)
+        {
+            TimeSpan diff = DateTime.Now - last_time_shot;
+            if (diff < shot_animation_duration)
+            {
+                return shoot_texture;
+            }
+        }
+        return texture;
+    }
 
     public virtual void draw(SpriteBatch spritebatch, GameTime gameTime)
-    {   
+    {
+        Texture2D tex = get_current_texture();
 
         if (moving_direction == -1)
         {
-            spritebatch.Draw(texture,
+            spritebatch.Draw(tex,
                              currentRect, null, Color.White, 0f, Vector2.Zero,
                              SpriteEffects.FlipHorizontally, 0f
                              );
         }
         else
         {
-            spritebatch.Draw(texture,
+            spritebatch.Draw(tex,
                             currentRect, null, Color.White, 0f, Vector2.Zero,
                             SpriteEffects.None, 0f
                             );

--- a/src/PlayerStuff/PlayerFactory.cs
+++ b/src/PlayerStuff/PlayerFactory.cs
@@ -37,6 +37,7 @@ public static class PlayerFactory
     private static GraphicsDevice _graphicsDevice;
 
     private static Texture2D[] playerTextures = new Texture2D[TypesCount+1];
+    private static Texture2D[] playerShootTextures = new Texture2D[TypesCount+1];
     private static Texture2D[] smt = new Texture2D[TypesCount+1];  //special_move_textures
 
     private static Texture2D[] playerInfo = new Texture2D[TypesCount+1];  //Texturen, die den PlayerTyp beschreiben
@@ -55,6 +56,16 @@ public static class PlayerFactory
         playerTextures[(int)Types.Wizzard] = Content.Load<Texture2D>("players/Wizzard");
         playerTextures[(int)Types.RandomPlayer] = Content.Load<Texture2D>("players/questionmark");
         playerTextures[(int)Types.Robot] = Content.Load<Texture2D>("players/Robot");
+
+        playerShootTextures[(int)Types.Spiderman] = Content.Load<Texture2D>("Spiderman2");
+        playerShootTextures[(int)Types.Knight] = Content.Load<Texture2D>("Knight2");
+        playerShootTextures[(int)Types.Sonic] = Content.Load<Texture2D>("Sonic2");
+        playerShootTextures[(int)Types.Standart] = Content.Load<Texture2D>("Standart2");
+        playerShootTextures[(int)Types.Ninja] = Content.Load<Texture2D>("ninja2");
+        playerShootTextures[(int)Types.Mario] = Content.Load<Texture2D>("Mario 2");
+        playerShootTextures[(int)Types.Wizzard] = Content.Load<Texture2D>("Wizard2");
+        playerShootTextures[(int)Types.RandomPlayer] = Content.Load<Texture2D>("players/questionmark");
+        playerShootTextures[(int)Types.Robot] = Content.Load<Texture2D>("players/questionmark");
 
 
         smt[(int)Types.Spiderman] = Content.Load<Texture2D>("special_move_textures/special_move_texture_spiderman");
@@ -88,23 +99,23 @@ public static class PlayerFactory
         switch (playerType)
         {
             case Types.Standart:
-                return new Player(_graphicsDevice, position, GetPlayerTexture(playerType), getSMT(playerType), id, controls);
+                return new Player(_graphicsDevice, position, GetPlayerTexture(playerType), GetShootTexture(playerType), getSMT(playerType), id, controls);
             case Types.Sonic:
-                return new Sonic(_graphicsDevice, position, GetPlayerTexture(playerType), getSMT(playerType), id, controls);
+                return new Sonic(_graphicsDevice, position, GetPlayerTexture(playerType), GetShootTexture(playerType), getSMT(playerType), id, controls);
             case Types.Spiderman:
-                return new Spiderman(_graphicsDevice, position, GetPlayerTexture(playerType), getSMT(playerType), id, controls);
+                return new Spiderman(_graphicsDevice, position, GetPlayerTexture(playerType), GetShootTexture(playerType), getSMT(playerType), id, controls);
             case Types.Knight:
-                return new Knight(_graphicsDevice, position, GetPlayerTexture(playerType), getSMT(playerType), id, controls);
+                return new Knight(_graphicsDevice, position, GetPlayerTexture(playerType), GetShootTexture(playerType), getSMT(playerType), id, controls);
             case Types.Ninja:
-                return new Ninja(_graphicsDevice, position, GetPlayerTexture(playerType), getSMT(playerType), id, controls);
+                return new Ninja(_graphicsDevice, position, GetPlayerTexture(playerType), GetShootTexture(playerType), getSMT(playerType), id, controls);
             case Types.Mario:
-                return new Mario(_graphicsDevice, position, GetPlayerTexture(playerType), getSMT(playerType), id, controls);
+                return new Mario(_graphicsDevice, position, GetPlayerTexture(playerType), GetShootTexture(playerType), getSMT(playerType), id, controls);
             case Types.Wizzard:
-                return new Wizzard(_graphicsDevice, position, GetPlayerTexture(playerType), getSMT(playerType), id, controls);
+                return new Wizzard(_graphicsDevice, position, GetPlayerTexture(playerType), GetShootTexture(playerType), getSMT(playerType), id, controls);
             case Types.RandomPlayer:
-                return new RandomPlayer(_graphicsDevice, position, GetPlayerTexture(playerType), getSMT(playerType), id, controls);
+                return new RandomPlayer(_graphicsDevice, position, GetPlayerTexture(playerType), GetShootTexture(playerType), getSMT(playerType), id, controls);
             default:
-                return new Player(_graphicsDevice, position, GetPlayerTexture(playerType), getSMT(playerType), id, controls);
+                return new Player(_graphicsDevice, position, GetPlayerTexture(playerType), GetShootTexture(playerType), getSMT(playerType), id, controls);
         }
     }
 
@@ -131,13 +142,18 @@ public static class PlayerFactory
         return smt[(int)playerType];
     }
 
+    public static Texture2D GetShootTexture(Types playerType)
+    {
+        return playerShootTextures[(int)playerType];
+    }
+
     public static Texture2D GetPlayerInfoTexture(Types playerType)
     {
         return playerInfo[(int)playerType];
     }
-    
+
     public static Robot CreateRobot(GameLogic game)
     {
-        return new Robot( _graphicsDevice, Vector2.Zero, GetPlayerTexture(Types.Robot), getSMT(Types.Robot), 2, Game1.rightPlayerControls, game);
+        return new Robot( _graphicsDevice, Vector2.Zero, GetPlayerTexture(Types.Robot), GetShootTexture(Types.Robot), getSMT(Types.Robot), 2, Game1.rightPlayerControls, game);
     }
 }

--- a/src/PlayerStuff/RandomPlayer.cs
+++ b/src/PlayerStuff/RandomPlayer.cs
@@ -12,8 +12,8 @@ using System;
 public class RandomPlayer: Player
 {
     //Konstruktor for RandomPlayer
-    public RandomPlayer(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D special_move_texture, int player, PlayerControls controls)
-              : base(graphicsDevice, position1, texture1, special_move_texture, player, controls)
+    public RandomPlayer(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D shoot_texture, Texture2D special_move_texture, int player, PlayerControls controls)
+              : base(graphicsDevice, position1, texture1, shoot_texture, special_move_texture, player, controls)
     {}
 
 

--- a/src/PlayerStuff/Robot.cs
+++ b/src/PlayerStuff/Robot.cs
@@ -9,8 +9,8 @@ public class Robot : Player
 
     private GameLogic game;
 
-    public Robot(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D special_move_texture1, int player, PlayerControls controls, GameLogic game)
-              : base(graphicsDevice, position1, texture1, special_move_texture1, player, controls)
+    public Robot(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D shoot_texture1, Texture2D special_move_texture1, int player, PlayerControls controls, GameLogic game)
+              : base(graphicsDevice, position1, texture1, shoot_texture1, special_move_texture1, player, controls)
     {
         this.game = game;
     }

--- a/src/PlayerStuff/Spiderman.cs
+++ b/src/PlayerStuff/Spiderman.cs
@@ -8,8 +8,8 @@ public class Spiderman: Player
 {
 
     //Konstruktor for Spiderman
-    public Spiderman(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D special_move_texture, int player, PlayerControls controls)
-              : base(graphicsDevice, position1, texture1, special_move_texture, player, controls)
+    public Spiderman(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D shoot_texture, Texture2D special_move_texture, int player, PlayerControls controls)
+              : base(graphicsDevice, position1, texture1, shoot_texture, special_move_texture, player, controls)
     {}
 
 

--- a/src/PlayerStuff/Wizzard.cs
+++ b/src/PlayerStuff/Wizzard.cs
@@ -45,8 +45,8 @@ public class Wizzard: Player
 
 
     //Konstruktor for Wizzard
-    public Wizzard(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D special_move_texture, int player, PlayerControls controls)
-              : base(graphicsDevice, position1, texture1, special_move_texture, player, controls)
+    public Wizzard(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D shoot_texture, Texture2D special_move_texture, int player, PlayerControls controls)
+              : base(graphicsDevice, position1, texture1, shoot_texture, special_move_texture, player, controls)
     {}
 
 
@@ -144,16 +144,18 @@ public class Wizzard: Player
         if (is_teleporting) { return; }
 
 
+        Texture2D tex = get_current_texture();
+
         if (moving_direction == -1)
         {
-            spriteBatch.Draw(texture,
+            spriteBatch.Draw(tex,
                              currentRect, null, Color.White, 0f, Vector2.Zero,
                              SpriteEffects.FlipHorizontally, 0f
                              );
         }
         else
         {
-            spriteBatch.Draw(texture,
+            spriteBatch.Draw(tex,
                             currentRect, null, Color.White, 0f, Vector2.Zero,
                             SpriteEffects.None, 0f
                             );

--- a/src/PlayerStuff/sonic.cs
+++ b/src/PlayerStuff/sonic.cs
@@ -20,8 +20,8 @@ public class Sonic: Player
 
 
     //Konstruktor for Sonic
-    public Sonic(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D special_move_texture, int player, PlayerControls controls)
-              : base(graphicsDevice, position1, texture1, special_move_texture, player, controls)
+    public Sonic(GraphicsDevice graphicsDevice, Vector2 position1, Texture2D texture1, Texture2D shoot_texture, Texture2D special_move_texture, int player, PlayerControls controls)
+              : base(graphicsDevice, position1, texture1, shoot_texture, special_move_texture, player, controls)
     {}
 
 


### PR DESCRIPTION
## Summary
- add support for alternate shooting textures with time-limited display
- load new `(CharName)2` assets and wire through player factory
- update character rendering and input handling to trigger shot animation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c08f14ebc48324aa6da8b720a12c44