### PR TITLE
Ensure consistent player sprite size when shooting

### DIFF
--- a/src/PlayerStuff/Player.cs
+++ b/src/PlayerStuff/Player.cs
@@ -390,19 +390,41 @@ public class Player
     {
         Texture2D tex = get_current_texture();
 
+        // Draw the player scaled so that the sprite always matches the
+        // RectangleWidth/RectangleHeight of the player.  Some shooting
+        // textures have a different resolution than the normal textures
+        // which previously resulted in the player appearing larger or
+        // smaller while shooting.  By computing an explicit scale factor
+        // based on the desired rectangle and the actual texture size we
+        // ensure a consistent on screen size for all animations.
+
+        Vector2 scale = new Vector2(
+            (float)RectangleWidth / tex.Width,
+            (float)RectangleHeight / tex.Height);
+
         if (moving_direction == -1)
         {
             spritebatch.Draw(tex,
-                             currentRect, null, Color.White, 0f, Vector2.Zero,
-                             SpriteEffects.FlipHorizontally, 0f
-                             );
+                             position,
+                             null,
+                             Color.White,
+                             0f,
+                             Vector2.Zero,
+                             scale,
+                             SpriteEffects.FlipHorizontally,
+                             0f);
         }
         else
         {
             spritebatch.Draw(tex,
-                            currentRect, null, Color.White, 0f, Vector2.Zero,
-                            SpriteEffects.None, 0f
-                            );
+                             position,
+                             null,
+                             Color.White,
+                             0f,
+                             Vector2.Zero,
+                             scale,
+                             SpriteEffects.None,
+                             0f);
         }
 
         if (can_move == false)

--- a/src/PlayerStuff/Wizzard.cs
+++ b/src/PlayerStuff/Wizzard.cs
@@ -146,19 +146,36 @@ public class Wizzard: Player
 
         Texture2D tex = get_current_texture();
 
+        // Similar to the base player draw logic we scale the texture
+        // explicitly so that shoot animations keep the same visual size
+        // as the normal sprite.
+        Vector2 scale = new Vector2(
+            (float)RectangleWidth / tex.Width,
+            (float)RectangleHeight / tex.Height);
+
         if (moving_direction == -1)
         {
             spriteBatch.Draw(tex,
-                             currentRect, null, Color.White, 0f, Vector2.Zero,
-                             SpriteEffects.FlipHorizontally, 0f
-                             );
+                             position,
+                             null,
+                             Color.White,
+                             0f,
+                             Vector2.Zero,
+                             scale,
+                             SpriteEffects.FlipHorizontally,
+                             0f);
         }
         else
         {
             spriteBatch.Draw(tex,
-                            currentRect, null, Color.White, 0f, Vector2.Zero,
-                            SpriteEffects.None, 0f
-                            );
+                             position,
+                             null,
+                             Color.White,
+                             0f,
+                             Vector2.Zero,
+                             scale,
+                             SpriteEffects.None,
+                             0f);
 
         }
 


### PR DESCRIPTION
## Summary
- scale player textures so shooting animations match normal sprite size
- apply the same scaling logic to wizard's custom draw method

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c09f83141c83248b6f40605df2475b